### PR TITLE
Fix issue with client being created with every call

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,8 @@ func main() {
 	<-stopChan // wait for SIGINT
 	log.Info().Msg("Shutting down server...")
 	// shut down gracefully, but wait no longer than 5 seconds before halting
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+  defer cancel()
   cli.Close()
 	srv.Shutdown(ctx)
 


### PR DESCRIPTION
The docker is client is created once on startup and then closed graceful when the application gets the appropriate signal.